### PR TITLE
Fix regex to enable autocomplete on dot

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ const { AutoLanguageClient } = require("atom-languageclient");
 
 // Ref: https://github.com/nteract/hydrogen/blob/master/lib/autocomplete-provider.js#L33
 // adapted from http://stackoverflow.com/q/5474008
-const PYTHON_REGEX = /([^\d\W]|[\u00A0-\uFFFF])[\w.\u00A0-\uFFFF]*$/;
+const PYTHON_REGEX = /(([^\d\W]|[\u00A0-\uFFFF])[\w.\u00A0-\uFFFF]*)|\.$/;
 
 class PythonLanguageClient extends AutoLanguageClient {
   getGrammarScopes() {


### PR DESCRIPTION
Since the regex test the completion prefix and not the whole line, we need to include `.` as a valid identifier.

Fixes #16 