### PR TITLE
Configure jedi all_scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "atom-languageclient": "^0.6.4",
     "shell-env": "^0.3.0"
   },
-  "enhancedScopes": [
-    "source.python"
-  ],
+  "enhancedScopes": ["source.python"],
   "configSchema": {
     "pylsPath": {
       "title": "Python Language Server Path",
@@ -102,8 +100,16 @@
             "enabled": {
               "title": "Enabled",
               "type": "boolean",
+              "order": 1,
               "default": true,
               "description": "Enable or disable Jedi Symbols."
+            },
+            "all_scopes": {
+              "title": "All Scopes",
+              "type": "boolean",
+              "default": false,
+              "description":
+                "If enabled lists the names of all scopes instead of only the module namespace. Requires pyls 0.7.0+"
             }
           }
         },
@@ -121,7 +127,8 @@
               "title": "Threshold",
               "type": "number",
               "default": 15,
-              "description": "The minimum threshold that triggers warnings about cyclomatic complexity."
+              "description":
+                "The minimum threshold that triggers warnings about cyclomatic complexity."
             }
           }
         },


### PR DESCRIPTION
This PR adds a new config option to allow users to configure if symbols from all scopes are shown or not:
## `all_scopes=false` (default / old behavior)
<img width="656" alt="all_scopes=false (default)" src="https://user-images.githubusercontent.com/13285808/30754882-c6cf7614-9fc4-11e7-97e3-1353f9e8600f.png">

## `all_scopes=true`
<img width="658" alt=" all_scopes=true" src="https://user-images.githubusercontent.com/13285808/30754895-d3b36e9e-9fc4-11e7-9ba4-92e774305a58.png">

Requires `pyls` 0.7+

Unfortunately `pyls` and `jedi` only support flat symbol structure.