### PR TITLE
Get environment variable w/o killing CPU on linux

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,4 @@
 const cp = require("child_process");
-const shellEnv = require("shell-env");
 const { shell } = require("electron");
 const { AutoLanguageClient } = require("atom-languageclient");
 
@@ -29,10 +28,10 @@ class PythonLanguageClient extends AutoLanguageClient {
   }
 
   async startServerProcess(projectPath) {
-    const env = await shellEnv();
+    await atom.updateProcessEnv();
     const childProcess = cp.spawn(atom.config.get("ide-python.pylsPath"), {
       cwd: projectPath,
-      env: env
+      env: process.env
     });
     childProcess.on("error", err =>
       atom.notifications.addError(


### PR DESCRIPTION
This is an attempt to fix #20.

I do not have access to a Mac, so I cannot check verify that this change does't re-introduce #4. Although, hacking Travis CI on a different atom package seemed to indicate that `process.env` contained the correct information on the mac environment, but Travis CI also starts Atom from a shell.

Ref:
- https://github.com/atom/atom/pull/14164
- https://github.com/atom/atom/pull/13200
- #27 