### PR TITLE
Only use shell-env on mac

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -29,7 +29,8 @@ class PythonLanguageClient extends AutoLanguageClient {
   }
 
   async startServerProcess(projectPath) {
-    const env = await shellEnv();
+    // For some reason Atom only detects the correct env if started from the command line on Mac.
+    const env = process.platform === "darwin" ? await shellEnv() : process.env;
     const childProcess = cp.spawn(atom.config.get("ide-python.pylsPath"), {
       cwd: projectPath,
       env: env


### PR DESCRIPTION
For some reason Atom only detects the correct env if started from the command line on Mac.

Strangely `process.env.PATH` is correct when evaluating it in the dev tools. Unfortunately in this file `process.env` has the wrong value. `atom.updateProcessEnv()` doesn't help either. 😕

This looks like a bug in Atom.

@kbrose Could you test if this fixes the CPU issues on Linux?