### PR TITLE
Fix "Unable to start pyls" for Debian

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -30,7 +30,7 @@ class PythonLanguageClient extends AutoLanguageClient {
 
   async startServerProcess(projectPath) {
     // For some reason Atom only detects the correct env if started from the command line on Mac and Debian.
-    const env = process.platform === "darwin" || process.platform === "darwin" ? await shellEnv() : process.env;
+    const env = process.platform === "darwin" || process.platform === "linux" ? await shellEnv() : process.env;
     const childProcess = cp.spawn(atom.config.get("ide-python.pylsPath"), {
       cwd: projectPath,
       env: env

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,8 +29,8 @@ class PythonLanguageClient extends AutoLanguageClient {
   }
 
   async startServerProcess(projectPath) {
-    // For some reason Atom only detects the correct env if started from the command line on Mac.
-    const env = process.platform === "darwin" ? await shellEnv() : process.env;
+    // For some reason Atom only detects the correct env if started from the command line on Mac and Debian.
+    const env = process.platform === "darwin" || process.platform === "darwin" ? await shellEnv() : process.env;
     const childProcess = cp.spawn(atom.config.get("ide-python.pylsPath"), {
       cwd: projectPath,
       env: env


### PR DESCRIPTION
This PR fixes my issue https://github.com/lgeiger/ide-python/issues/31 on my Debian machine.
Definitely needs further review as it affects all linux machines!

As with the already implemented workaround for Mac, this is not more than a workaround and might not get down to the root of the problem.