### PR TITLE
Await Atom's shell environment load

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,4 @@
 const cp = require("child_process");
-const shellEnv = require("shell-env");
 const { shell } = require("electron");
 const { AutoLanguageClient } = require("atom-languageclient");
 
@@ -29,11 +28,10 @@ class PythonLanguageClient extends AutoLanguageClient {
   }
 
   async startServerProcess(projectPath) {
-    // For some reason Atom only detects the correct env if started from the command line on Mac.
-    const env = process.platform === "darwin" ? await shellEnv() : process.env;
+    await new Promise(resolve => atom.whenShellEnvironmentLoaded(resolve));
+
     const childProcess = cp.spawn(atom.config.get("ide-python.pylsPath"), {
-      cwd: projectPath,
-      env: env
+      cwd: projectPath
     });
     childProcess.on("error", err =>
       atom.notifications.addError(

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "atom": ">=1.21.0 <2.0.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.6.4",
-    "shell-env": "^0.3.0"
+    "atom-languageclient": "^0.6.4"
   },
   "enhancedScopes": [
     "source.python"


### PR DESCRIPTION
Wait until Atom's shell environment is fully loaded before starting the language server process.

This removes `shell-env` as a dependency an and removes the workaround for fixing #20.

Fixes #31
Closes #32 
Probably related to #34