### PR TITLE
Add support for pycodestyle options and multiple config sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,21 +27,29 @@
   "dependencies": {
     "atom-languageclient": "^0.8.2"
   },
-  "enhancedScopes": [
-    "source.python"
-  ],
+  "enhancedScopes": ["source.python"],
   "configSchema": {
     "pylsPath": {
       "title": "Python Language Server Path",
       "order": 1,
       "type": "string",
       "default": "pyls",
-      "description": "Absolute path to ```pyls``` executable."
+      "description": "Absolute path to `pyls` executable."
     },
     "pylsPlugins": {
       "title": "Python Language Server Plugins",
       "type": "object",
       "properties": {
+        "configurationSources": {
+          "type": "array",
+          "default": ["pycodestyle"],
+          "description":
+            "List of configuration sources to use. Requires `pyls` 0.12.1+",
+          "items": {
+            "type": "string",
+            "enum": ["pycodestyle", "pyflakes"]
+          }
+        },
         "jedi_completion": {
           "title": "Jedi Completion",
           "type": "object",
@@ -117,7 +125,8 @@
               "title": "All Scopes",
               "type": "boolean",
               "default": true,
-              "description": "If enabled lists the names of all scopes instead of only the module namespace. Requires pyls 0.7.0+"
+              "description":
+                "If enabled lists the names of all scopes instead of only the module namespace. Requires `pyls` 0.7.0+"
             }
           }
         },
@@ -135,7 +144,8 @@
               "title": "Threshold",
               "type": "number",
               "default": 15,
-              "description": "The minimum threshold that triggers warnings about cyclomatic complexity."
+              "description":
+                "The minimum threshold that triggers warnings about cyclomatic complexity."
             }
           }
         },
@@ -148,6 +158,70 @@
               "type": "boolean",
               "default": true,
               "description": "Enable or disable PyCodeStyle."
+            },
+            "exclude": {
+              "type": "array",
+              "default": [
+                ".svn",
+                "CVS",
+                ".bzr",
+                ".hg",
+                ".git",
+                "__pycache__",
+                ".tox"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description":
+                "Exclude files or directories which match these patterns. Requires `pyls` 0.12.1+"
+            },
+            "filename": {
+              "type": "array",
+              "default": ["*.py"],
+              "items": {
+                "type": "string"
+              },
+              "description":
+                "When parsing directories, only check filenames matching these patterns. Requires `pyls` 0.12.1+"
+            },
+            "select": {
+              "type": "array",
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "description":
+                "Select errors and warnings Requires `pyls` 0.12.1+"
+            },
+            "ignore": {
+              "type": "array",
+              "default": [
+                "E121",
+                "E123",
+                "E126",
+                "E226",
+                "E24",
+                "E704",
+                "W503"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description":
+                "Ignore errors and warnings Requires `pyls` 0.12.1+"
+            },
+            "hangClosing": {
+              "type": "boolean",
+              "default": false,
+              "description":
+                "Hang closing bracket instead of matching indentation of opening bracket's line. Requires `pyls` 0.12.1+"
+            },
+            "maxLineLength": {
+              "type": "number",
+              "default": 79,
+              "description":
+                "Set maximum allowed line length. Requires `pyls` 0.12.1+"
             }
           }
         },
@@ -172,6 +246,18 @@
               "type": "boolean",
               "default": true,
               "description": "Enable or disable PyFlakes."
+            }
+          }
+        },
+        "rope_completion": {
+          "title": "Rope Completion",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description":
+                "Enable or disable the plugin. Requires `pyls` 0.12.1+"
             }
           }
         },


### PR DESCRIPTION
`pyls` 0.12.0 added support for configuring pycodestyle options via the IDE settings.

closes #47 
closes #42 
closes #9 

**TODO:**
- [ ] `pycodestyle` ignore setting is not working https://github.com/palantir/python-language-server/pull/211
- [x] `pycodestyle` filename and exclude settings are not working -> Removed since not very important for now
- [x] test `pycodestyle` config from `setup.cfg` to see if the behaviour matches
