### PR TITLE
Upgrade atom-languageclient

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,21 +11,21 @@ class PythonLanguageClient extends AutoLanguageClient {
   getGrammarScopes() {
     return ["source.python"];
   }
+
   getLanguageName() {
     return "Python";
   }
+
   getServerName() {
     return "pyls";
   }
 
-  postInitialization({ connection }) {
-    this._disposable.add(
-      atom.config.observe("ide-python.pylsPlugins", params => {
-        connection.didChangeConfiguration({
-          settings: { pyls: { plugins: params } }
-        });
-      })
-    );
+  getRootConfigurationKey() {
+    return "ide-python.pylsPlugins";
+  }
+
+  mapConfigurationObject(configuration) {
+    return { pyls: { plugins: configuration } }
   }
 
   async startServerProcess(projectPath) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "atom": ">=1.21.0 <2.0.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.8.0"
+    "atom-languageclient": "^0.8.2"
   },
   "enhancedScopes": [
     "source.python"


### PR DESCRIPTION
This allows us to watch for config changes via `atom-languageclient`.

With this release the server will be automatically restarted if the connection gets killed.
Closes #3 
Closes #50 
Closes #63