### PR TITLE
Add support for more pyls options

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,21 +27,29 @@
   "dependencies": {
     "atom-languageclient": "^0.8.2"
   },
-  "enhancedScopes": [
-    "source.python"
-  ],
+  "enhancedScopes": ["source.python"],
   "configSchema": {
     "pylsPath": {
       "title": "Python Language Server Path",
       "order": 1,
       "type": "string",
       "default": "pyls",
-      "description": "Absolute path to ```pyls``` executable."
+      "description": "Absolute path to `pyls` executable."
     },
     "pylsPlugins": {
       "title": "Python Language Server Plugins",
       "type": "object",
       "properties": {
+        "configurationSources": {
+          "type": "array",
+          "default": ["pycodestyle"],
+          "description":
+            "List of configuration sources to use. Requires `pyls` 0.12.1+",
+          "items": {
+            "type": "string",
+            "enum": ["pycodestyle", "pyflakes"]
+          }
+        },
         "jedi_completion": {
           "title": "Jedi Completion",
           "type": "object",
@@ -117,7 +125,8 @@
               "title": "All Scopes",
               "type": "boolean",
               "default": true,
-              "description": "If enabled lists the names of all scopes instead of only the module namespace. Requires pyls 0.7.0+"
+              "description":
+                "If enabled lists the names of all scopes instead of only the module namespace. Requires `pyls` 0.7.0+"
             }
           }
         },
@@ -135,7 +144,8 @@
               "title": "Threshold",
               "type": "number",
               "default": 15,
-              "description": "The minimum threshold that triggers warnings about cyclomatic complexity."
+              "description":
+                "The minimum threshold that triggers warnings about cyclomatic complexity."
             }
           }
         },
@@ -148,6 +158,18 @@
               "type": "boolean",
               "default": true,
               "description": "Enable or disable PyCodeStyle."
+            },
+            "hangClosing": {
+              "type": "boolean",
+              "default": false,
+              "description":
+                "Hang closing bracket instead of matching indentation of opening bracket's line. Requires `pyls` 0.12.1+"
+            },
+            "maxLineLength": {
+              "type": "number",
+              "default": 79,
+              "description":
+                "Set maximum allowed line length. Requires `pyls` 0.12.1+"
             }
           }
         },
@@ -172,6 +194,18 @@
               "type": "boolean",
               "default": true,
               "description": "Enable or disable PyFlakes."
+            }
+          }
+        },
+        "rope_completion": {
+          "title": "Rope Completion",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description":
+                "Enable or disable the plugin. Requires `pyls` 0.12.1+"
             }
           }
         },


### PR DESCRIPTION
Since `pyls` still has some problems with `pycodestyle` option handling https://github.com/palantir/python-language-server/pull/211 this adds support for the options that work:
- Add support for multiple pycodestyle config sources
- Add `hangClosing` option
- Add `maxLineLength` setting (closes #47)
- Add possibility to use Rope instead of Jedi

Closes #58 for now.