### PR TITLE
Defer package activation until shell env is loaded

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -46,7 +46,6 @@ class PythonLanguageClient extends AutoLanguageClient {
   }
 
   async startServerProcess(projectPath) {
-    await new Promise(resolve => atom.whenShellEnvironmentLoaded(resolve));
     const venvPath =
       (await detectPipEnv(projectPath)) ||
       (await detectVirtualEnv(projectPath));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "enhancedScopes": [
     "source.python"
   ],
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "configSchema": {
     "python": {
       "title": "Python Executable",


### PR DESCRIPTION
This PR defers package activation until the shell environment is loaded. This should speed up startup time of Atom and doesn't impact `ide-python` since we need to wait for the shell environment to be loaded anyway.

See https://github.com/prettier/prettier-atom/pull/485