### PR TITLE
Revert "Forward pyls stderr to frontend"

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -102,12 +102,6 @@ class PythonLanguageClient extends AutoLanguageClient {
         );
       }
     });
-
-    childProcess.stderr.on("data", data => {
-      atom.notifications.addWarning("Python language server", {
-        description: `${data}`
-      });
-    });
     return childProcess;
   }
 


### PR DESCRIPTION
As per discussion this pyls throws a lot of warnings on some systems. This reverts the change introducing the logging in the UI. Error messages can still be viewed in the developer tools.

Fixes #156 
Reverts lgeiger/ide-python#155