### PR TITLE
Tweak Python path help text

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "order": 1,
       "type": "string",
       "default": "python",
-      "description": "Absolute path of your Python binary. This is used to launch the Python language server. Make sure to install `pyls` for this version of Python. Changes will take effect after a restart of the language server. Use $PIPENV_PATH if you want to use the pipenv path of your project"
+      "description": "Absolute path of your Python binary. This is used to launch the Python language server. Make sure to install `pyls` for this version of Python. Changes will take effect after a restart of the language server. Use `$PIPENV_PATH/bin/python` if you want to use the pipenv path of your project"
     },
     "pylsConfigurationSources": {
       "order": 2,


### PR DESCRIPTION
Use full Python binary path (`$PIPENV/bin/python`) so as to not trip up skimmers 😅